### PR TITLE
Fix GitHub release asset upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -60,4 +60,6 @@ jobs:
         if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber
+        run: >-
+          gh release upload "${{ github.event.release.tag_name }}" dist/* --clobber
+          --repo "${{ github.repository }}"

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -51,6 +51,12 @@ def test_publish_workflow_uses_oidc_without_api_token() -> None:
     assert "password:" not in workflow
 
 
+def test_publish_workflow_uploads_release_assets_without_a_checkout() -> None:
+    workflow = read(".github/workflows/publish.yml")
+
+    assert '--repo "${{ github.repository }}"' in workflow
+
+
 def test_dependabot_tracks_python_and_actions_monthly() -> None:
     config = read(".github/dependabot.yml")
 


### PR DESCRIPTION
## Summary
- pass the repository explicitly when attaching release artifacts
- add a regression test for publish jobs without a checkout

## Verification
- 36 package tests passed
- 31 legacy tests passed
- Ruff passed
- v0.1.0 assets were manually attached using the exact workflow artifacts