### PR TITLE
release: nature-academic-search 0.1.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Academic research skills and MCP tools maintained by wp-a.",
-    "version": "0.1.0"
+    "version": "0.1.1"
   },
   "plugins": [
     {

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -5,8 +5,8 @@
 - Support Python 3.10-3.13.
 - Keep MCP Python SDK on `mcp>=1.27,<2` until a tested v2 migration is released.
 - Preserve `search_papers`, `get_paper_by_id`, `get_citation`, and `lookup_mesh`.
-- Keep `pyproject.toml`, plugin manifests, marketplace metadata, and `.mcp.json`
-  on the same semantic version.
+- Keep `pyproject.toml`, plugin manifests, versioned marketplace metadata, and
+  `.mcp.json` on the same semantic version.
 
 ## Pull request gates
 
@@ -39,17 +39,21 @@ matching protected GitHub environments before publishing.
 
 ## Release checklist
 
-For the initial release, replace `v0.1.0` with the intended version in later
-releases.
+Choose the intended semantic version before starting and use it consistently:
+
+```bash
+VERSION=x.y.z
+```
 
 1. Confirm the package name is still available and no unexpected release exists.
-2. Update versions in `pyproject.toml`, both plugin manifests, both marketplace
-   files, and the plugin `.mcp.json` pin.
+2. Update versions in `pyproject.toml`, `src/nature_academic_search/__init__.py`,
+   both plugin manifests, Claude marketplace metadata, tests, and the plugin
+   `.mcp.json` pin. The Codex marketplace has no version field.
 3. Run every pull request gate and explicit network smoke test.
 4. Trigger `publish.yml` with `testpypi`; install the uploaded wheel in a clean
    environment and verify all four MCP tools.
-5. Create tag and GitHub release `v0.1.0`. Publishing the release triggers the
-   production PyPI environment.
+5. Create tag and GitHub release `v${VERSION}`. Publishing the release triggers
+   the production PyPI environment.
 6. Install from public PyPI, run `nature-academic-search preflight`, and validate
    both plugin marketplaces from the tag.
 7. Record incompatibilities or release-specific migration notes in the GitHub

--- a/plugins/nature-academic-search/.claude-plugin/plugin.json
+++ b/plugins/nature-academic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "nature-academic-search",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Search, verify, deduplicate, and export academic literature across PubMed, CrossRef, and arXiv.",
   "author": {
     "name": "wp-a",

--- a/plugins/nature-academic-search/.codex-plugin/plugin.json
+++ b/plugins/nature-academic-search/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nature-academic-search",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Search, verify, deduplicate, and export academic literature across PubMed, CrossRef, and arXiv.",
   "author": {
     "name": "wp-a",

--- a/plugins/nature-academic-search/.mcp.json
+++ b/plugins/nature-academic-search/.mcp.json
@@ -4,7 +4,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "nature-academic-search==0.1.0",
+        "nature-academic-search==0.1.1",
         "nature-academic-search-mcp"
       ]
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nature-academic-search"
-version = "0.1.0"
+version = "0.1.1"
 description = "Academic literature search and citation workflows for PubMed, CrossRef, and arXiv"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/nature_academic_search/__init__.py
+++ b/src/nature_academic_search/__init__.py
@@ -1,4 +1,3 @@
 """Academic search workflows for PubMed, CrossRef, and arXiv."""
 
-__version__ = "0.1.0"
-
+__version__ = "0.1.1"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,7 +33,7 @@ def test_version_comes_from_package_metadata() -> None:
     completed = run_module("--version")
 
     assert completed.returncode == 0, completed.stderr
-    assert completed.stdout.strip() == "nature-academic-search 0.1.0"
+    assert completed.stdout.strip() == "nature-academic-search 0.1.1"
 
 
 def test_preflight_help_does_not_access_network() -> None:

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -17,14 +17,14 @@ def load_project() -> dict:
         return tomllib.load(handle)
 
 
-def test_package_exposes_initial_version() -> None:
+def test_package_exposes_release_version() -> None:
     sys.path.insert(0, str(ROOT / "src"))
     try:
         package = importlib.import_module("nature_academic_search")
     finally:
         sys.path.pop(0)
 
-    assert package.__version__ == "0.1.0"
+    assert package.__version__ == "0.1.1"
 
 
 def test_project_declares_supported_python_and_mcp_versions() -> None:

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 try:
@@ -8,10 +9,32 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
     import tomli as tomllib
 
 ROOT = Path(__file__).resolve().parents[1]
+RELEASE_VERSION = "0.1.1"
 
 
 def read(path: str) -> str:
     return (ROOT / path).read_text(encoding="utf-8")
+
+
+def read_json(path: str) -> dict:
+    return json.loads(read(path))
+
+
+def test_release_version_is_synchronized_across_package_and_plugins() -> None:
+    with (ROOT / "pyproject.toml").open("rb") as handle:
+        package_version = tomllib.load(handle)["project"]["version"]
+
+    codex_manifest = read_json("plugins/nature-academic-search/.codex-plugin/plugin.json")
+    claude_manifest = read_json("plugins/nature-academic-search/.claude-plugin/plugin.json")
+    claude_marketplace = read_json(".claude-plugin/marketplace.json")
+    mcp = read_json("plugins/nature-academic-search/.mcp.json")
+    mcp_args = mcp["mcpServers"]["nature-academic-search"]["args"]
+
+    assert package_version == RELEASE_VERSION
+    assert codex_manifest["version"] == RELEASE_VERSION
+    assert claude_manifest["version"] == RELEASE_VERSION
+    assert claude_marketplace["metadata"]["version"] == RELEASE_VERSION
+    assert f"nature-academic-search=={RELEASE_VERSION}" in mcp_args
 
 
 def test_project_declares_mit_license_file() -> None:
@@ -88,6 +111,6 @@ def test_maintenance_runbook_records_release_gates() -> None:
         "python -m pytest",
         "twine check",
         "claude plugin validate --strict",
-        "v0.1.0",
+        "VERSION",
     ):
         assert required in runbook


### PR DESCRIPTION
## Summary
- release the Chinese-first README and revised research workflow skill through PyPI
- synchronize package, Codex plugin, Claude plugin, marketplace, and MCP pins at 0.1.1
- make the maintenance checklist version-agnostic

## Verification
- [x] Ruff
- [x] 40 package tests
- [x] 31 legacy MCP contract tests
- [x] Codex, Claude Code, and skill validators
- [x] PubMed, CrossRef, and arXiv preflight
- [x] wheel/sdist build and Twine validation
- [x] clean local wheel install and four-tool MCP contract