### PR TITLE
release: Academic Paper Search 0.1.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
   },
   "metadata": {
     "description": "Academic research skills and MCP tools maintained by wp-a.",
-    "version": "0.1.1"
+    "version": "0.1.2"
   },
   "plugins": [
     {

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -10,7 +10,7 @@
   "plugins": [
     {
       "name": "nature-academic-search",
-      "description": "Search, verify, deduplicate, and export literature across PubMed, CrossRef, and arXiv.",
+      "description": "Academic Paper Search for verified, deduplicated literature across PubMed, CrossRef, and arXiv.",
       "source": "./plugins/nature-academic-search",
       "strict": true
     }

--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 <div align="center">
 
-# Nature Academic Search
+# Academic Paper Search
 
 **让 Codex / Claude Code 完成可复现的文献检索、核验与引用导出。**
+
+安装标识仍为 `nature-academic-search`，现有命令与配置无需迁移。
 
 不止返回几个论文标题：同时检索 PubMed、CrossRef 和 arXiv，合并重复记录，核验 DOI / PMID / arXiv ID，区分正式论文与预印本，并把来源失败如实写进结果。
 
@@ -91,7 +93,7 @@ bash install.sh researcher@example.com
 
 ## 为什么是“核验优先”
 
-| 常见检索输出 | Nature Academic Search |
+| 常见检索输出 | Academic Paper Search |
 |---|---|
 | 只给标题和链接 | 同时保留查询、检索日期、标识符与来源追踪 |
 | 多库结果重复出现 | 按 DOI、PMID、arXiv ID、题名与年份合并 |

--- a/SKILL.md
+++ b/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   CrossRef, and arXiv.
 ---
 
-# Nature Academic Search
+# Academic Paper Search
 
 使用捆绑的 MCP 服务组织可复现检索。把每条记录当作待核验的证据，不把搜索结果当作可凭空补全的引用。
 

--- a/docs/maintenance.md
+++ b/docs/maintenance.md
@@ -37,6 +37,12 @@ PyPI and TestPyPI each require a one-time Trusted Publisher mapping:
 The workflow uses GitHub OIDC and must not contain a PyPI API token. Create the
 matching protected GitHub environments before publishing.
 
+## Distribution policy
+
+PyPI is a low-maintenance runtime distribution for the pinned `uvx` plugin
+command. Publish only when code, fixes, embedded skill behavior, or required
+metadata changes. Do not create a second package for the display brand.
+
 ## Release checklist
 
 Choose the intended semantic version before starting and use it consistently:
@@ -50,8 +56,10 @@ VERSION=x.y.z
    both plugin manifests, Claude marketplace metadata, tests, and the plugin
    `.mcp.json` pin. The Codex marketplace has no version field.
 3. Run every pull request gate and explicit network smoke test.
-4. Trigger `publish.yml` with `testpypi`; install the uploaded wheel in a clean
-   environment and verify all four MCP tools.
+4. If the TestPyPI Trusted Publisher is configured, trigger `publish.yml` with
+   `testpypi`; install the uploaded wheel in a clean environment and verify all
+   four MCP tools. Otherwise record the skip and require a clean local wheel
+   install plus a successful pull-request build before production publishing.
 5. Create tag and GitHub release `v${VERSION}`. Publishing the release triggers
    the production PyPI environment.
 6. Install from public PyPI, run `nature-academic-search preflight`, and validate

--- a/docs/plans/2026-07-15-academic-paper-search-brand-design.md
+++ b/docs/plans/2026-07-15-academic-paper-search-brand-design.md
@@ -1,0 +1,101 @@
+# Academic Paper Search Brand Design
+
+**Date:** 2026-07-15
+**Status:** Approved
+
+## Objective
+
+Change the user-facing product name from **Nature Academic Search** to
+**Academic Paper Search** while preserving every installed identifier and command.
+The new name should immediately communicate that the project searches academic
+papers, without forcing users to migrate packages, plugins, skills, MCP entries,
+or repository URLs.
+
+## Brand Model
+
+Use two explicit layers:
+
+- **Display brand:** `Academic Paper Search`
+- **Technical identifier:** `nature-academic-search`
+
+The display brand appears in user-facing headings, plugin UI metadata, package
+descriptions, prompts, and repository metadata. The technical identifier remains
+stable wherever software resolves, installs, invokes, or upgrades the project.
+
+## Immutable Technical Identifiers
+
+Do not rename any of the following:
+
+- GitHub repository: `wp-a/nature-academic-search`
+- PyPI project: `nature-academic-search`
+- Python import package: `nature_academic_search`
+- CLI command: `nature-academic-search`
+- MCP entry point: `nature-academic-search-mcp`
+- MCP server key: `nature-academic-search`
+- skill name and invocation: `nature-academic-search` and
+  `$nature-academic-search`
+- plugin name: `nature-academic-search`
+- marketplace name: `wp-a-academic-tools`
+
+Existing installation commands, links, configurations, and upgrade paths must
+continue to work unchanged.
+
+## User-Facing Surfaces
+
+Change the display brand consistently in:
+
+1. README title and introductory copy.
+2. Root and packaged `SKILL.md` headings.
+3. Codex `agents/openai.yaml` `display_name`.
+4. Codex plugin `interface.displayName` and user-facing descriptions.
+5. Claude plugin and marketplace descriptions where a descriptive brand phrase
+   is supported without changing their required identifier fields.
+6. Python project description shown by PyPI package metadata.
+7. GitHub repository description.
+8. Release title and notes for version `0.1.2`.
+
+The first README paragraph should state that `nature-academic-search` is the
+technical package and plugin ID so users understand why install commands differ
+from the visible brand.
+
+## PyPI Policy
+
+Keep PyPI as a low-maintenance runtime distribution, not as a separate brand or
+marketing destination. It remains necessary because the plugin starts the pinned
+runtime through:
+
+```text
+uvx --from nature-academic-search==<version> nature-academic-search-mcp
+```
+
+Publish to PyPI only when code, fixes, embedded skill behavior, or required
+metadata changes. Do not create a second `academic-paper-search` distribution.
+The one-time display-brand change requires `0.1.2` because the wheel embeds the
+skill and Codex UI metadata.
+
+## Release Scope
+
+Release `0.1.2` as a metadata and branding patch:
+
+- synchronize package, Python module, plugin manifests, Claude marketplace, and
+  MCP pin versions;
+- make no changes to search logic, source adapters, CLI commands, or MCP schemas;
+- preserve the four MCP tools: `search_papers`, `get_paper_by_id`,
+  `get_citation`, and `lookup_mesh`;
+- state explicitly in release notes that there are no breaking identifier or API
+  changes.
+
+## Verification
+
+The change is complete when:
+
+- tests assert the new display brand on every supported UI surface;
+- tests assert all technical identifiers remain unchanged;
+- package and plugin versions are synchronized at `0.1.2`;
+- root, plugin, and wheel-embedded skill content remains synchronized;
+- Codex, Claude Code, and skill validators pass;
+- wheel and sdist pass Twine validation;
+- Codex and Claude Code marketplace installs report version `0.1.2`;
+- a clean public PyPI install exposes the display brand in the embedded skill and
+  still launches all four MCP tools through the unchanged commands;
+- GitHub and PyPI release assets have matching SHA-256 digests.

--- a/docs/plans/2026-07-15-academic-paper-search-brand-implementation.md
+++ b/docs/plans/2026-07-15-academic-paper-search-brand-implementation.md
@@ -1,0 +1,280 @@
+# Academic Paper Search Brand Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Apply the `Academic Paper Search` display brand without changing any technical identifier, then publish the synchronized branding metadata and embedded skill as version `0.1.2`.
+
+**Architecture:** Treat display brand and technical identity as separate contracts. Content tests protect every user-facing brand surface while existing package and plugin tests preserve `nature-academic-search` identifiers; a second TDD cycle synchronizes the patch version before the normal PR, OIDC, and public-install release gates.
+
+**Tech Stack:** Markdown, JSON, YAML, TOML, pytest, Hatchling, Twine, GitHub CLI, PyPI Trusted Publishing, Codex and Claude Code plugin validators.
+
+---
+
+### Task 1: Define the display-brand and identifier contracts
+
+**Files:**
+- Modify: `tests/test_release_metadata.py`
+- Modify: `tests/test_plugin_artifacts.py`
+
+**Step 1: Add a failing package and README brand test**
+
+Define:
+
+```python
+DISPLAY_BRAND = "Academic Paper Search"
+TECHNICAL_ID = "nature-academic-search"
+```
+
+Add assertions that:
+
+- `README.md` contains `# Academic Paper Search` and explains that
+  `nature-academic-search` remains the technical package and plugin ID;
+- the project name and both script names remain unchanged;
+- the project description starts with the display brand;
+- the README no longer presents `Nature Academic Search` as the current product
+  name.
+
+**Step 2: Add a failing plugin and skill brand test**
+
+Require both synchronized skill files to use `# Academic Paper Search`, while
+their YAML `name` remains `nature-academic-search`. Require:
+
+```python
+assert codex_manifest["name"] == TECHNICAL_ID
+assert codex_manifest["interface"]["displayName"] == DISPLAY_BRAND
+assert claude_manifest["name"] == TECHNICAL_ID
+assert openai_interface["display_name"] == DISPLAY_BRAND
+```
+
+Also require the Codex/Claude manifest descriptions and Claude marketplace plugin
+description to include `Academic Paper Search`.
+
+**Step 3: Run the focused tests and verify RED**
+
+```bash
+python -m pytest tests/test_release_metadata.py tests/test_plugin_artifacts.py -v
+```
+
+Expected: only the new display-brand assertions fail; existing identifier and
+plugin structure tests pass.
+
+**Step 4: Commit the failing contracts**
+
+```bash
+git add tests/test_release_metadata.py tests/test_plugin_artifacts.py
+git commit -m "test: define Academic Paper Search brand contract"
+```
+
+### Task 2: Apply the display brand without renaming identifiers
+
+**Files:**
+- Modify: `README.md`
+- Modify: `SKILL.md`
+- Modify: `pyproject.toml`
+- Modify: `.claude-plugin/marketplace.json`
+- Modify: `plugins/nature-academic-search/.codex-plugin/plugin.json`
+- Modify: `plugins/nature-academic-search/.claude-plugin/plugin.json`
+- Modify: `plugins/nature-academic-search/skills/nature-academic-search/SKILL.md`
+- Modify: `plugins/nature-academic-search/skills/nature-academic-search/agents/openai.yaml`
+
+**Step 1: Update README branding**
+
+Change the H1 and comparison table header to `Academic Paper Search`. Add one
+short sentence below the value proposition:
+
+```text
+安装标识仍为 `nature-academic-search`，现有命令与配置无需迁移。
+```
+
+Do not alter installation commands, repository links, CLI names, MCP names, or
+skill invocation examples.
+
+**Step 2: Update synchronized skill headings and UI metadata**
+
+Change only the Markdown headings in both skill files to `Academic Paper Search`.
+Regenerate or update `agents/openai.yaml` so `display_name` is the new brand;
+preserve `$nature-academic-search` in `default_prompt` and preserve YAML skill
+`name: nature-academic-search`.
+
+**Step 3: Update package and plugin descriptions**
+
+Prefix the Python package, Codex plugin, Claude plugin, and Claude marketplace
+plugin descriptions with `Academic Paper Search`. Change Codex
+`interface.displayName` to the new brand. Do not change any JSON `name`, source,
+marketplace, entry-point, or MCP key.
+
+**Step 4: Run focused tests and validators**
+
+```bash
+python -m pytest tests/test_release_metadata.py tests/test_plugin_artifacts.py -v
+python /Users/wangpeng/.codex/skills/.system/skill-creator/scripts/quick_validate.py plugins/nature-academic-search/skills/nature-academic-search
+python /Users/wangpeng/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py plugins/nature-academic-search
+claude plugin validate --strict plugins/nature-academic-search
+```
+
+Expected: every command exits 0, the two skill files compare equal, and all
+technical identifiers remain unchanged.
+
+**Step 5: Commit the display brand**
+
+```bash
+git add README.md SKILL.md pyproject.toml .claude-plugin/marketplace.json plugins/nature-academic-search
+git commit -m "docs: present Academic Paper Search brand"
+```
+
+### Task 3: Prepare the synchronized 0.1.2 patch release
+
+**Files:**
+- Modify: `tests/test_cli.py`
+- Modify: `tests/test_package_metadata.py`
+- Modify: `tests/test_release_metadata.py`
+- Modify: `pyproject.toml`
+- Modify: `src/nature_academic_search/__init__.py`
+- Modify: `.claude-plugin/marketplace.json`
+- Modify: `plugins/nature-academic-search/.codex-plugin/plugin.json`
+- Modify: `plugins/nature-academic-search/.claude-plugin/plugin.json`
+- Modify: `plugins/nature-academic-search/.mcp.json`
+- Modify: `docs/maintenance.md`
+
+**Step 1: Change tests to expect 0.1.2**
+
+Update the hard-coded CLI, package, and release contract version from `0.1.1`
+to `0.1.2`. Run:
+
+```bash
+python -m pytest tests/test_cli.py tests/test_package_metadata.py tests/test_release_metadata.py tests/test_plugin_artifacts.py -v
+```
+
+Expected: version assertions fail because production files still report `0.1.1`.
+
+**Step 2: Synchronize every versioned surface**
+
+Set `0.1.2` in the Python project, module, both plugin manifests, Claude
+marketplace metadata, and MCP `uvx` package pin. Keep the Codex marketplace
+unchanged because it has no version field.
+
+**Step 3: Record the low-maintenance PyPI policy**
+
+State in `docs/maintenance.md` that PyPI remains the pinned plugin runtime and is
+published only for code, fixes, embedded skill behavior, or required metadata.
+Make TestPyPI conditional on its separate Trusted Publisher being configured;
+otherwise require clean-wheel and PR-build evidence and record the skip.
+
+**Step 4: Run the focused tests and verify GREEN**
+
+Run the focused command from Step 1 again. Expected: all tests pass.
+
+**Step 5: Commit the release preparation**
+
+```bash
+git add tests pyproject.toml src/nature_academic_search/__init__.py .claude-plugin/marketplace.json plugins/nature-academic-search docs/maintenance.md
+git commit -m "release: prepare Academic Paper Search 0.1.2"
+```
+
+### Task 4: Run release gates and verify built artifacts
+
+**Files:**
+- Verify all packaged and plugin files
+
+**Step 1: Run local gates**
+
+```bash
+python -m ruff check src tests
+python -m pytest
+python -m pytest mcp-server/tests
+nature-academic-search preflight
+```
+
+Expected: Ruff passes, at least 40 package tests pass, all 31 legacy tests pass,
+and PubMed/CrossRef/arXiv are reachable.
+
+**Step 2: Run skill and plugin validators again**
+
+Run the three validator commands from Task 2. Expected: all pass.
+
+**Step 3: Build outside the repository and validate**
+
+```bash
+python -m build --outdir /tmp/nature-academic-search-012-dist
+twine check /tmp/nature-academic-search-012-dist/*
+```
+
+Verify wheel metadata reports project `nature-academic-search`, version `0.1.2`,
+and the description brand `Academic Paper Search`. Compare the wheel-embedded
+SKILL and `agents/openai.yaml` byte-for-byte with repository sources.
+
+**Step 4: Install the local wheel in a clean environment**
+
+Verify unchanged CLI and stdio MCP entry points, version `0.1.2`, the embedded
+display brand, and exactly four MCP tools.
+
+**Step 5: Audit the branch**
+
+Run `git diff --check`, inspect every changed file, and confirm no current product
+surface still presents `Nature Academic Search` except the approved historical
+design record.
+
+### Task 5: Integrate through PR and update GitHub metadata
+
+**Files:**
+- No additional repository files expected
+
+**Step 1: Push and create a pull request**
+
+Push `brand/academic-paper-search-0.1.2`, create a PR against `main`, and include
+the display-brand boundary, unchanged IDs, local gates, and release plan.
+
+**Step 2: Wait for both push and pull-request CI runs**
+
+Require Python 3.10–3.13 and build jobs to pass. Merge only after all required
+checks are green.
+
+**Step 3: Synchronize local main and verify merge CI**
+
+Pull `main`, verify its package version and display brand, and wait for its push
+CI run.
+
+**Step 4: Update GitHub description**
+
+Set a Chinese-first description beginning with `Academic Paper Search` while
+retaining `Codex`, `Claude Code`, `MCP`, `PubMed`, `CrossRef`, and `arXiv` search
+keywords. Read it back through the GitHub API.
+
+### Task 6: Publish and verify version 0.1.2
+
+**Files:**
+- No further source changes expected
+
+**Step 1: Confirm release uniqueness**
+
+Verify PyPI `0.1.2`, GitHub Release `v0.1.2`, and tag `v0.1.2` do not exist.
+
+**Step 2: Create and inspect a draft GitHub Release**
+
+Target the merged `main` commit. Release notes must state the display-brand
+change, unchanged technical IDs and commands, PyPI runtime role, and no breaking
+API change.
+
+**Step 3: Publish and watch production OIDC**
+
+Publish the draft and require build, PyPI Trusted Publishing, attestations, and
+GitHub Release asset upload to pass. Do not dispatch TestPyPI because its
+independent Trusted Publisher is known to be unconfigured.
+
+**Step 4: Verify public distribution**
+
+Compare PyPI and GitHub Release SHA-256 digests. Install
+`nature-academic-search==0.1.2` without cache in a clean environment and verify:
+
+- CLI reports `0.1.2`;
+- packaged skill displays `Academic Paper Search`;
+- PubMed, CrossRef, and arXiv preflight succeeds;
+- stdio and pinned `uvx` expose exactly four MCP tools;
+- Codex and Claude Code marketplace installs report `0.1.2` while retaining
+  plugin ID `nature-academic-search`.
+
+**Step 5: Clean up and audit final state**
+
+Remove the merged worktree and local branch. Confirm `main` equals `origin/main`,
+HEAD is tagged `v0.1.2`, the public release is not a draft/prerelease, and PyPI
+lists wheel and sdist files.

--- a/plugins/nature-academic-search/.claude-plugin/plugin.json
+++ b/plugins/nature-academic-search/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "nature-academic-search",
   "version": "0.1.1",
-  "description": "Search, verify, deduplicate, and export academic literature across PubMed, CrossRef, and arXiv.",
+  "description": "Academic Paper Search for verified, deduplicated literature across PubMed, CrossRef, and arXiv.",
   "author": {
     "name": "wp-a",
     "url": "https://github.com/wp-a"

--- a/plugins/nature-academic-search/.claude-plugin/plugin.json
+++ b/plugins/nature-academic-search/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/plugin.schema.json",
   "name": "nature-academic-search",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Academic Paper Search for verified, deduplicated literature across PubMed, CrossRef, and arXiv.",
   "author": {
     "name": "wp-a",

--- a/plugins/nature-academic-search/.codex-plugin/plugin.json
+++ b/plugins/nature-academic-search/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nature-academic-search",
   "version": "0.1.1",
-  "description": "Search, verify, deduplicate, and export academic literature across PubMed, CrossRef, and arXiv.",
+  "description": "Academic Paper Search for verified, deduplicated literature across PubMed, CrossRef, and arXiv.",
   "author": {
     "name": "wp-a",
     "url": "https://github.com/wp-a"
@@ -12,9 +12,9 @@
   "keywords": ["academic-search", "arxiv", "citations", "crossref", "pubmed"],
   "skills": "./skills/",
   "interface": {
-    "displayName": "Nature Academic Search",
-    "shortDescription": "Verified multi-source literature search",
-    "longDescription": "Search PubMed, CrossRef, and arXiv; resolve identifiers; deduplicate records; build MeSH strategies; and export citations.",
+    "displayName": "Academic Paper Search",
+    "shortDescription": "Verified multi-source academic paper search",
+    "longDescription": "Academic Paper Search across PubMed, CrossRef, and arXiv; resolve identifiers, deduplicate records, build MeSH strategies, and export citations.",
     "developerName": "wp-a",
     "category": "Research",
     "capabilities": ["Search", "Citations"],

--- a/plugins/nature-academic-search/.codex-plugin/plugin.json
+++ b/plugins/nature-academic-search/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nature-academic-search",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Academic Paper Search for verified, deduplicated literature across PubMed, CrossRef, and arXiv.",
   "author": {
     "name": "wp-a",

--- a/plugins/nature-academic-search/.mcp.json
+++ b/plugins/nature-academic-search/.mcp.json
@@ -4,7 +4,7 @@
       "command": "uvx",
       "args": [
         "--from",
-        "nature-academic-search==0.1.1",
+        "nature-academic-search==0.1.2",
         "nature-academic-search-mcp"
       ]
     }

--- a/plugins/nature-academic-search/skills/nature-academic-search/SKILL.md
+++ b/plugins/nature-academic-search/skills/nature-academic-search/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   CrossRef, and arXiv.
 ---
 
-# Nature Academic Search
+# Academic Paper Search
 
 使用捆绑的 MCP 服务组织可复现检索。把每条记录当作待核验的证据，不把搜索结果当作可凭空补全的引用。
 

--- a/plugins/nature-academic-search/skills/nature-academic-search/agents/openai.yaml
+++ b/plugins/nature-academic-search/skills/nature-academic-search/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "Nature Academic Search"
+  display_name: "Academic Paper Search"
   short_description: "跨 PubMed、CrossRef、arXiv 检索、核验并导出可信文献"
   default_prompt: "使用 $nature-academic-search 检索并核验这个研究主题的文献，去重后区分正式论文与预印本。"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "nature-academic-search"
 version = "0.1.1"
-description = "Academic literature search and citation workflows for PubMed, CrossRef, and arXiv"
+description = "Academic Paper Search for verified PubMed, CrossRef, and arXiv literature workflows"
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "wp-a" }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nature-academic-search"
-version = "0.1.1"
+version = "0.1.2"
 description = "Academic Paper Search for verified PubMed, CrossRef, and arXiv literature workflows"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/nature_academic_search/__init__.py
+++ b/src/nature_academic_search/__init__.py
@@ -1,3 +1,3 @@
 """Academic search workflows for PubMed, CrossRef, and arXiv."""
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,7 +33,7 @@ def test_version_comes_from_package_metadata() -> None:
     completed = run_module("--version")
 
     assert completed.returncode == 0, completed.stderr
-    assert completed.stdout.strip() == "nature-academic-search 0.1.1"
+    assert completed.stdout.strip() == "nature-academic-search 0.1.2"
 
 
 def test_preflight_help_does_not_access_network() -> None:

--- a/tests/test_package_metadata.py
+++ b/tests/test_package_metadata.py
@@ -24,7 +24,7 @@ def test_package_exposes_release_version() -> None:
     finally:
         sys.path.pop(0)
 
-    assert package.__version__ == "0.1.1"
+    assert package.__version__ == "0.1.2"
 
 
 def test_project_declares_supported_python_and_mcp_versions() -> None:

--- a/tests/test_plugin_artifacts.py
+++ b/tests/test_plugin_artifacts.py
@@ -14,6 +14,8 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
 ROOT = Path(__file__).resolve().parents[1]
 PLUGIN = ROOT / "plugins" / "nature-academic-search"
 PLUGIN_SKILL = PLUGIN / "skills" / "nature-academic-search"
+DISPLAY_BRAND = "Academic Paper Search"
+TECHNICAL_ID = "nature-academic-search"
 
 
 def project_version() -> str:
@@ -103,10 +105,27 @@ def test_skill_routes_chinese_research_requests_and_reports_verification() -> No
 def test_codex_skill_interface_targets_chinese_researchers() -> None:
     interface = load_yaml(PLUGIN_SKILL / "agents" / "openai.yaml")["interface"]
 
-    assert interface["display_name"] == "Nature Academic Search"
+    assert interface["display_name"] == DISPLAY_BRAND
     assert "文献" in interface["short_description"]
     assert "$nature-academic-search" in interface["default_prompt"]
     assert "检索" in interface["default_prompt"]
+
+
+def test_display_brand_changes_without_renaming_skill_or_plugins() -> None:
+    skill = (ROOT / "SKILL.md").read_text(encoding="utf-8")
+    codex_manifest = load_json(PLUGIN / ".codex-plugin" / "plugin.json")
+    claude_manifest = load_json(PLUGIN / ".claude-plugin" / "plugin.json")
+    claude_marketplace = load_json(ROOT / ".claude-plugin" / "marketplace.json")
+
+    assert f"# {DISPLAY_BRAND}" in skill
+    assert "# Nature Academic Search" not in skill
+    assert codex_manifest["name"] == TECHNICAL_ID
+    assert codex_manifest["interface"]["displayName"] == DISPLAY_BRAND
+    assert DISPLAY_BRAND in codex_manifest["description"]
+    assert claude_manifest["name"] == TECHNICAL_ID
+    assert DISPLAY_BRAND in claude_manifest["description"]
+    assert claude_marketplace["plugins"][0]["name"] == TECHNICAL_ID
+    assert DISPLAY_BRAND in claude_marketplace["plugins"][0]["description"]
 
 
 def test_marketplaces_point_to_the_packaged_plugin() -> None:

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -10,6 +10,8 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
 
 ROOT = Path(__file__).resolve().parents[1]
 RELEASE_VERSION = "0.1.1"
+DISPLAY_BRAND = "Academic Paper Search"
+TECHNICAL_ID = "nature-academic-search"
 
 
 def read(path: str) -> str:
@@ -43,6 +45,22 @@ def test_project_declares_mit_license_file() -> None:
 
     assert project["license"] == {"file": "LICENSE"}
     assert read("LICENSE").startswith("MIT License\n")
+
+
+def test_display_brand_changes_without_renaming_package_or_commands() -> None:
+    with (ROOT / "pyproject.toml").open("rb") as handle:
+        project = tomllib.load(handle)["project"]
+    readme = read("README.md")
+
+    assert f"# {DISPLAY_BRAND}" in readme
+    assert "Nature Academic Search" not in readme
+    assert "安装标识仍为 `nature-academic-search`" in readme
+    assert project["name"] == TECHNICAL_ID
+    assert project["description"].startswith(DISPLAY_BRAND)
+    assert set(project["scripts"]) == {
+        TECHNICAL_ID,
+        "nature-academic-search-mcp",
+    }
 
 
 def test_readme_documents_all_supported_install_paths() -> None:

--- a/tests/test_release_metadata.py
+++ b/tests/test_release_metadata.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
     import tomli as tomllib
 
 ROOT = Path(__file__).resolve().parents[1]
-RELEASE_VERSION = "0.1.1"
+RELEASE_VERSION = "0.1.2"
 DISPLAY_BRAND = "Academic Paper Search"
 TECHNICAL_ID = "nature-academic-search"
 
@@ -130,5 +130,7 @@ def test_maintenance_runbook_records_release_gates() -> None:
         "twine check",
         "claude plugin validate --strict",
         "VERSION",
+        "low-maintenance runtime distribution",
+        "If the TestPyPI Trusted Publisher is configured",
     ):
         assert required in runbook


### PR DESCRIPTION
## Summary
- change the user-facing brand to Academic Paper Search while preserving every nature-academic-search identifier and command
- synchronize package, embedded skill, Codex/Claude plugin metadata, marketplace metadata, and MCP pin at 0.1.2
- document PyPI as the low-maintenance pinned runtime and make TestPyPI conditional on its independent publisher setup

## Verification
- [x] Ruff
- [x] 42 package tests
- [x] 31 legacy MCP contract tests
- [x] skill, Codex plugin, and Claude plugin validators
- [x] PubMed, CrossRef, and arXiv preflight
- [x] wheel/sdist build and Twine validation
- [x] clean local wheel install, embedded brand check, and four-tool MCP contract
- [x] independent skill brand/identifier forward test